### PR TITLE
Enhance multi-sport demo mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,22 @@ jobs:
       working-directory: ./web-admin
       run: npm run test:ci
 
+    - name: Set up Python
+      if: matrix.node-version == '20.x'
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install Python dependencies
+      if: matrix.node-version == '20.x'
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run Python unit tests
+      if: matrix.node-version == '20.x'
+      run: python -m unittest discover
+
     - name: Upload coverage reports
       uses: codecov/codecov-action@v4
       with:

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ When both WNBA and NHL games are active, the system uses intelligent rules to de
 |------|---------|-------------|
 | **Default** | `python app.py` | Runs the multi-sport scoreboard with your configuration |
 | **Simulation** | `python app.py --sim` | Render frames to `out/frame.png` without hardware |
-| **Demo** | `python app.py --demo` | Loop a scripted demo game for testing |
+| **Demo** | `python app.py --demo` | Loop scripted demos; add `--demo-sport nhl --demo-rotation 90` to rotate |
 
 ### ⚙️ **Configuration Options**
 
@@ -152,6 +152,11 @@ When both WNBA and NHL games are active, the system uses intelligent rules to de
 # Sport enablement
 ENABLE_WNBA=true               # Enable/disable WNBA
 ENABLE_NHL=true                # Enable/disable NHL
+
+# Demo configuration
+DEMO_MODE=false                # Enable demo mode
+DEMO_SPORTS=wnba,nhl           # Comma-separated sports for demo rotation
+DEMO_ROTATION_SECONDS=120      # Seconds before rotating to next sport in demo
 
 # Priority configuration  
 SPORT_PRIORITIES=wnba,nhl      # Priority order (comma-separated)
@@ -647,6 +652,12 @@ ls -la out/frame.png
 
 # Test with demo data
 python app.py --sim --demo
+
+# Limit demo mode to NHL only
+python app.py --sim --demo --demo-sport nhl
+
+# Rotate between WNBA and NHL every two minutes
+python app.py --sim --demo --demo-sport wnba --demo-sport nhl --demo-rotation 120
 
 # Test on hardware (requires sudo for GPIO access)
 sudo -E $(pwd)/.venv/bin/python app.py --once

--- a/app.py
+++ b/app.py
@@ -14,7 +14,7 @@ from src.model.sport_game import EnhancedGameSnapshot
 from typing import Optional
 from src.sports.aggregator import MultiSportAggregator
 from src.render.renderer import Renderer
-from src.demo.simulator import DemoSimulator
+from src.demo.simulator import DemoSimulator, parse_demo_options
 from src.runtime.reload import ConfigWatcher
 from src.runtime.adaptive_refresh import AdaptiveRefreshManager
 
@@ -33,6 +33,17 @@ def parse_args():
     parser.add_argument("--sim", action="store_true", help="Force simulate display (no matrix)")
     parser.add_argument("--once", action="store_true", help="Run one update cycle and exit")
     parser.add_argument("--demo", action="store_true", help="Run in demo mode with a simulated game")
+    parser.add_argument(
+        "--demo-sport",
+        action="append",
+        help="Limit demo mode to specific sports (can be provided multiple times)",
+    )
+    parser.add_argument(
+        "--demo-rotation",
+        type=int,
+        default=None,
+        help="Number of seconds to show each sport before rotating in demo mode",
+    )
     return parser.parse_args()
 
 
@@ -74,7 +85,26 @@ def main():
 
     demo_env = os.getenv("DEMO_MODE", "false").lower() == "true"
     use_demo = args.demo or demo_env
-    demo = DemoSimulator(cfg) if use_demo else None
+
+    demo_options = None
+    if use_demo:
+        env_demo_sports = os.getenv("DEMO_SPORTS")
+        forced_sports = args.demo_sport or (
+            env_demo_sports.split(",") if env_demo_sports else None
+        )
+        env_rotation = os.getenv("DEMO_ROTATION_SECONDS")
+        rotation_seconds = args.demo_rotation
+        if rotation_seconds is None and env_rotation is not None:
+            try:
+                rotation_seconds = int(env_rotation)
+            except ValueError:
+                rotation_seconds = None
+        demo_options = parse_demo_options(
+            rotation_seconds=rotation_seconds,
+            forced_sports=forced_sports,
+        )
+
+    demo = DemoSimulator(multi_cfg, cfg, options=demo_options) if use_demo else None
     
     # Setup adaptive refresh manager
     refresh_manager = AdaptiveRefreshManager(cfg.refresh)

--- a/sport-demo.md
+++ b/sport-demo.md
@@ -1,0 +1,39 @@
+# Multi-Sport Demo Mode Enhancement Plan
+
+- [x] **Audit Current Demo Flow**
+  - [x] Trace how `--demo` and `DEMO_MODE` flow through `app.py`, `DemoSimulator`, and renderer selection. (`app.py` parses `--demo`, checks `DEMO_MODE`, instantiates `DemoSimulator(cfg)` instead of aggregator, and feeds its snapshots directly into the renderer loop.)
+  - [x] Document assumptions in `src/demo/simulator.py` that hard-code WNBA periods, scoring, and terminology. (Simulator uses 4×10-minute “quarters”, increments 1–3 points, labels status as `Q{n}/Final`, and only picks teams from the legacy favorites list, so non-WNBA sports would render the wrong structure.)
+  - [x] Identify other modules (web admin, config schema, docs) that reference demo behavior. (Docs mention `--demo`; no web-admin toggles exist yet, so introducing settings will require schema/UI updates.)
+  - [x] Capture current sport-specific gaps. (Demo uses WNBA timing/labels only, never sets sport metadata, and cannot express NHL overtime/shootout or other sport rhythms.)
+
+- [x] **Design Multi-Sport Demo Architecture**
+  - [x] Define a sport-agnostic demo interface (e.g., `BaseDemoSimulator`) that exposes common timeline hooks (`get_snapshot`, period metadata, scoring cadence). *(Plan: create abstract base class encapsulating start time management, scoring increments, and hook for sport-specific timing; standardize data exchange via `EnhancedGameSnapshot`.)*
+  - [x] Decide how to source per-sport defaults (favorite teams, period counts, clock behavior) when none are configured. *(Plan: pull from `MultiSportAppConfig` favorites when available; otherwise use bundled assets per sport; embed sport “rules” table for periods/clock/OT behavior.)*
+  - [x] Determine selection rules when multiple sports are enabled (round-robin, priority mirroring live aggregator, manual override). *(Plan: mimic aggregator priority order but allow optional round-robin demo cycling; expose overrides via CLI/env for deterministic demos.)*
+
+- [ ] **Implement Sport-Specific Simulators**
+  - [ ] Extract current WNBA logic into `WNBAInteractiveDemo` implementing the new interface. *(Plan: move existing simulator to a WNBA subclass; adjust to emit `EnhancedGameSnapshot` with sport metadata.)*
+  - [ ] Implement NHL (and other supported sports) demo simulators that mirror sport rules (periods, overtime, scoring ranges, terminology). *(Plan: build NHL demo with 3×20-minute periods, OT/shootout hooks, hockey-friendly scoring cadence; leave stubs for future sports.)*
+  - [ ] Provide generic fallback simulator if a sport lacks a bespoke implementation. *(Plan: simple clock/score ticker that uses sport priority order and displays minimal info until dedicated simulator arrives.)*
+
+- [ ] **Wire Up Demo Selection & Configuration**
+  - [ ] Update `app.py` to instantiate the correct simulator based on enabled sports/favorites. *(Plan: create factory that inspects `MultiSportAppConfig`, picks sport order, and instantiates per-sport simulators with shared clock manager.)*
+  - [ ] Allow optional CLI/env overrides to force a specific sport demo or cycle schedule. *(Plan: add `--demo-sport` and `DEMO_SPORTS`, plus `DEMO_ROTATION_SECONDS` to control cycling.)*
+  - [ ] Ensure configuration loader and schema validate any new demo settings. *(Plan: extend config schema + web-admin to accept demo preferences; default to legacy behavior when unset.)*
+
+- [x] **Enhance Rendering Support**
+  - [x] Verify renderer scenes handle any new timing/status values produced by additional sports (OT markers, shootouts, penalties, etc.). *(Renderer already surfaces `status_detail`; new timing values (`OT`, `Final/SO`) render without additional changes.)*
+  - [ ] Add sport-specific status indicators for demo outputs where needed. *(Optional future enhancement for richer hockey overlays.)*
+
+- [x] **Testing & Tooling**
+  - [x] Add unit tests for each simulator covering period progression, scoring cadence, and end-state transitions. *(Added `tests/test_demo_mode.py` for WNBA and NHL flows.)*
+  - [x] Add integration test (or lightweight harness) ensuring `--demo` cycles through enabled sports without exceptions. *(Rotation test exercises multi-sport cycling.)*
+  - [ ] Update CI scripts or instructions to cover the demo test suite. *(Existing test runner already covers `python -m unittest`; document reminder to include in CI.)*
+
+- [ ] **Documentation & Web Admin**
+  - [x] Update README and admin UI help text to describe multi-sport demo behavior and configuration options. *(README updated with new CLI/env options; admin UI updates remain optional in next iteration.)*
+  - [ ] Provide assets (animated GIFs/screenshots) demonstrating demo mode for each sport.
+
+- [ ] **QA & Sign-off**
+  - [ ] Perform manual runs on hardware/simulator to validate timing and visuals per sport.
+  - [ ] Collect feedback from stakeholders, iterate on scoring/period pacing as needed.

--- a/src/demo/simulator.py
+++ b/src/demo/simulator.py
@@ -1,115 +1,538 @@
 from __future__ import annotations
 
 import random
-from dataclasses import replace
+from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Dict, Iterable, List, Optional, Sequence
 
-from src.config.types import AppConfig
+from zoneinfo import ZoneInfo
+
+from src.config.multi_sport_types import MultiSportAppConfig
+from src.config.types import AppConfig, FavoriteTeam
 from src.model.game import GameSnapshot, GameState, TeamSide
+from src.model.sport_game import EnhancedGameSnapshot, GameTiming, SportTeam
+from src.sports.base import SportType
+
+DEFAULT_ROTATION_SECONDS = 120
+DEFAULT_PREGAME_SECONDS = 45
+
+
+@dataclass
+class DemoOptions:
+    """Runtime options for demo mode selection."""
+
+    rotation_seconds: int = DEFAULT_ROTATION_SECONDS
+    forced_sports: Optional[List[SportType]] = None
+
+
+def _fallback_identifier(name: str, default: str) -> str:
+    if not name:
+        return default
+    cleaned = "".join(ch for ch in name.upper() if ch.isalpha())
+    return (cleaned or default)[:3]
+
+
+def _favorite_to_team(
+    sport: SportType,
+    favorite: Optional[FavoriteTeam],
+    default_name: str,
+    default_id: str,
+    default_abbr: str,
+) -> SportTeam:
+    if favorite is None:
+        return SportTeam(
+            id=default_id,
+            name=default_name,
+            abbr=default_abbr,
+            score=0,
+            sport=sport,
+        )
+
+    name = favorite.name or default_name
+    abbr = favorite.abbr or _fallback_identifier(name, default_abbr)
+    team_id = favorite.id or abbr
+    return SportTeam(
+        id=str(team_id),
+        name=name,
+        abbr=abbr,
+        score=0,
+        sport=sport,
+    )
+
+
+class BaseSportDemo:
+    """Abstract base class encapsulating common demo behaviour."""
+
+    pregame_seconds = DEFAULT_PREGAME_SECONDS
+
+    def __init__(
+        self,
+        sport: SportType,
+        tz: ZoneInfo,
+        favorites: Sequence[FavoriteTeam],
+        *,
+        rng: Optional[random.Random] = None,
+    ) -> None:
+        self.sport = sport
+        self.tz = tz
+        self._favorites = list(favorites)
+        self.rng = rng or random.Random()
+        self._home: SportTeam
+        self._away: SportTeam
+        self._start_time: datetime
+        self._next_score_time: datetime
+        self._final_label: str = "Final"
+        self.reset(datetime.now(self.tz))
+
+    def reset(self, now_local: datetime) -> None:
+        away_fav = self._favorites[0] if self._favorites else None
+        home_fav = self._favorites[1] if len(self._favorites) > 1 else None
+        self._away = _favorite_to_team(self.sport, away_fav, "Away", "demo-away", "AWY")
+        self._home = _favorite_to_team(self.sport, home_fav, "Home", "demo-home", "HOM")
+        self._home.score = 0
+        self._away.score = 0
+        self._start_time = now_local + timedelta(seconds=self.pregame_seconds)
+        self._next_score_time = self._start_time
+        self._final_label = "Final"
+        self._reset_internal(now_local)
+
+    def get_snapshot(self, now_local: datetime) -> Optional[GameSnapshot]:
+        enhanced = self._build_snapshot(now_local)
+        if enhanced is None:
+            return None
+        return enhanced.to_legacy_game_snapshot()
+
+    def _schedule_next_score(self, now_local: datetime, *, minimum: int, maximum: int) -> None:
+        delta = self.rng.randint(minimum, maximum)
+        self._next_score_time = now_local + timedelta(seconds=delta)
+
+    def _maybe_award_points(self, now_local: datetime, choices: Sequence[int]) -> None:
+        if now_local >= self._next_score_time:
+            pts = self.rng.choice(list(choices))
+            target = self._home if self.rng.random() < 0.5 else self._away
+            target.score += pts
+            self._schedule_next_score(now_local, minimum=10, maximum=30)
+
+    # --- hooks for subclasses -------------------------------------------------
+
+    def _reset_internal(self, now_local: datetime) -> None:  # pragma: no cover - optional override
+        """Allow subclasses to seed additional state on reset."""
+
+    def _build_snapshot(self, now_local: datetime) -> Optional[EnhancedGameSnapshot]:
+        raise NotImplementedError
+
+
+class WNBADemoSimulator(BaseSportDemo):
+    """WNBA-style demo (legacy behaviour)."""
+
+    period_seconds = 10 * 60
+    period_count = 4
+
+    def _build_snapshot(self, now_local: datetime) -> Optional[EnhancedGameSnapshot]:
+        if now_local < self._start_time:
+            seconds_to_start = int((self._start_time - now_local).total_seconds())
+            return self._make_snapshot(
+                state=GameState.PRE,
+                period=0,
+                seconds_to_start=seconds_to_start,
+                display_clock="",
+                period_name="PRE",
+                is_overtime=False,
+            )
+
+        elapsed = int((now_local - self._start_time).total_seconds())
+        period_index = min(elapsed // self.period_seconds, self.period_count)
+
+        if period_index >= self.period_count:
+            return self._make_snapshot(
+                state=GameState.FINAL,
+                period=self.period_count,
+                seconds_to_start=-1,
+                display_clock="00:00",
+                period_name=self._final_label,
+                is_overtime=False,
+            )
+
+        self._maybe_award_points(now_local, choices=[1, 2, 3])
+
+        remaining = self.period_seconds - (elapsed % self.period_seconds)
+        clock = self._format_clock(remaining)
+        period_number = period_index + 1
+        return self._make_snapshot(
+            state=GameState.LIVE,
+            period=period_number,
+            seconds_to_start=-1,
+            display_clock=clock,
+            period_name=f"Q{period_number}",
+            is_overtime=False,
+        )
+
+    def _format_clock(self, seconds: int) -> str:
+        seconds = max(0, seconds)
+        minutes, secs = divmod(seconds, 60)
+        return f"{minutes:02d}:{secs:02d}"
+
+    def _make_snapshot(
+        self,
+        *,
+        state: GameState,
+        period: int,
+        seconds_to_start: int,
+        display_clock: str,
+        period_name: str,
+        is_overtime: bool,
+    ) -> EnhancedGameSnapshot:
+        timing = GameTiming(
+            current_period=period,
+            period_name=period_name,
+            period_max=self.period_count,
+            display_clock=display_clock,
+            clock_running=state == GameState.LIVE,
+            is_intermission=False,
+            is_overtime=is_overtime,
+            is_shootout=False,
+        )
+        return EnhancedGameSnapshot(
+            sport=self.sport,
+            event_id=f"{self.sport.value}-demo",
+            start_time_local=self._start_time,
+            state=state,
+            home=self._home,
+            away=self._away,
+            timing=timing,
+            seconds_to_start=seconds_to_start,
+            status_detail=period_name if state != GameState.FINAL else self._final_label,
+        )
+
+
+class NHLDemoSimulator(BaseSportDemo):
+    """NHL-style demo with regulation, overtime, and shootout."""
+
+    regulation_period_seconds = 20 * 60
+    regulation_periods = 3
+    overtime_seconds = 5 * 60
+
+    def _reset_internal(self, now_local: datetime) -> None:
+        self._overtime_start: Optional[datetime] = None
+        self._shootout_resolved = False
+        self._final_label = "Final"
+        # schedule first score with slower cadence for hockey
+        self._schedule_next_score(self._start_time, minimum=45, maximum=120)
+
+    def _build_snapshot(self, now_local: datetime) -> Optional[EnhancedGameSnapshot]:
+        if now_local < self._start_time:
+            seconds_to_start = int((self._start_time - now_local).total_seconds())
+            return self._snapshot(
+                state=GameState.PRE,
+                period=0,
+                seconds_to_start=seconds_to_start,
+                display_clock="",
+                period_name="Pre-game",
+                is_overtime=False,
+                is_shootout=False,
+            )
+
+        elapsed = int((now_local - self._start_time).total_seconds())
+        regulation_total = self.regulation_periods * self.regulation_period_seconds
+
+        if elapsed < regulation_total:
+            self._maybe_award_points(now_local, choices=[1])
+            period_index = elapsed // self.regulation_period_seconds
+            period_number = period_index + 1
+            remaining = self.regulation_period_seconds - (elapsed % self.regulation_period_seconds)
+            timing = self._base_timing(
+                period=period_number,
+                display_clock=self._format_clock(remaining),
+                is_overtime=False,
+                is_shootout=False,
+            )
+            return EnhancedGameSnapshot(
+                sport=self.sport,
+                event_id=f"{self.sport.value}-demo",
+                start_time_local=self._start_time,
+                state=GameState.LIVE,
+                home=self._home,
+                away=self._away,
+                timing=timing,
+                seconds_to_start=-1,
+                status_detail=f"P{period_number}",
+            )
+
+        # Regulation finished – decide on overtime/shootout/final.
+        if self._home.score != self._away.score:
+            # Regulation winner
+            return self._final_snapshot("Final")
+
+        # Overtime setup
+        if self._overtime_start is None:
+            self._overtime_start = self._start_time + timedelta(seconds=regulation_total)
+            # faster scoring cadence in overtime
+            self._schedule_next_score(now_local, minimum=15, maximum=45)
+
+        if now_local < self._overtime_start + timedelta(seconds=self.overtime_seconds):
+            self._maybe_award_points(now_local, choices=[1])
+            if self._home.score != self._away.score:
+                self._final_label = "Final/OT"
+                return self._final_snapshot("Final/OT")
+
+            ot_remaining = int(
+                (self._overtime_start + timedelta(seconds=self.overtime_seconds) - now_local).total_seconds()
+            )
+            timing = self._base_timing(
+                period=self.regulation_periods + 1,
+                display_clock=self._format_clock(ot_remaining),
+                is_overtime=True,
+                is_shootout=False,
+            )
+            return EnhancedGameSnapshot(
+                sport=self.sport,
+                event_id=f"{self.sport.value}-demo",
+                start_time_local=self._start_time,
+                state=GameState.LIVE,
+                home=self._home,
+                away=self._away,
+                timing=timing,
+                seconds_to_start=-1,
+                status_detail="OT",
+            )
+
+        # Shootout resolution
+        if not self._shootout_resolved:
+            winner = self._home if self.rng.random() < 0.5 else self._away
+            winner.score += 1
+            self._shootout_resolved = True
+            self._final_label = "Final/SO"
+
+        return self._final_snapshot("Final/SO")
+
+    def _format_clock(self, seconds: int) -> str:
+        seconds = max(0, seconds)
+        minutes, secs = divmod(seconds, 60)
+        return f"{minutes:02d}:{secs:02d}"
+
+    def _base_timing(
+        self,
+        *,
+        period: int,
+        display_clock: str,
+        is_overtime: bool,
+        is_shootout: bool,
+    ) -> GameTiming:
+        return GameTiming(
+            current_period=period,
+            period_name="SO" if is_shootout else ("OT" if is_overtime and period > self.regulation_periods else f"P{period}"),
+            period_max=self.regulation_periods,
+            display_clock=display_clock,
+            clock_running=True,
+            is_intermission=False,
+            is_overtime=is_overtime,
+            is_shootout=is_shootout,
+        )
+
+    def _final_snapshot(self, label: str) -> EnhancedGameSnapshot:
+        return self._snapshot(
+            state=GameState.FINAL,
+            period=self.regulation_periods,
+            seconds_to_start=-1,
+            display_clock="00:00",
+            period_name=label,
+            is_overtime="OT" in label,
+            is_shootout="SO" in label,
+        )
+
+    def _snapshot(
+        self,
+        *,
+        state: GameState,
+        period: int,
+        seconds_to_start: int,
+        display_clock: str,
+        period_name: str,
+        is_overtime: bool,
+        is_shootout: bool,
+    ) -> EnhancedGameSnapshot:
+        timing = GameTiming(
+            current_period=period,
+            period_name=period_name,
+            period_max=self.regulation_periods,
+            display_clock=display_clock,
+            clock_running=state == GameState.LIVE,
+            is_intermission=False,
+            is_overtime=is_overtime,
+            is_shootout=is_shootout,
+        )
+        return EnhancedGameSnapshot(
+            sport=self.sport,
+            event_id=f"{self.sport.value}-demo",
+            start_time_local=self._start_time,
+            state=state,
+            home=self._home,
+            away=self._away,
+            timing=timing,
+            seconds_to_start=seconds_to_start,
+            status_detail=period_name,
+        )
+
+
+class GenericFallbackDemo(BaseSportDemo):
+    """Simple ticker used when no dedicated simulator exists."""
+
+    period_seconds = 8 * 60
+
+    def _build_snapshot(self, now_local: datetime) -> Optional[EnhancedGameSnapshot]:
+        if now_local < self._start_time:
+            seconds_to_start = int((self._start_time - now_local).total_seconds())
+            return self._make_snapshot(
+                state=GameState.PRE,
+                period=0,
+                seconds_to_start=seconds_to_start,
+                display_clock="",
+                status="Demo",
+            )
+
+        elapsed = int((now_local - self._start_time).total_seconds())
+        if elapsed >= 3 * self.period_seconds:
+            return self._make_snapshot(
+                state=GameState.FINAL,
+                period=3,
+                seconds_to_start=-1,
+                display_clock="00:00",
+                status="Final",
+            )
+
+        self._maybe_award_points(now_local, choices=[1, 2])
+        remaining = self.period_seconds - (elapsed % self.period_seconds)
+        clock = self._format_clock(remaining)
+        period_number = 1 + elapsed // self.period_seconds
+        return self._make_snapshot(
+            state=GameState.LIVE,
+            period=period_number,
+            seconds_to_start=-1,
+            display_clock=clock,
+            status=f"Period {period_number}",
+        )
+
+    def _format_clock(self, seconds: int) -> str:
+        seconds = max(0, seconds)
+        minutes, secs = divmod(seconds, 60)
+        return f"{minutes:02d}:{secs:02d}"
+
+    def _make_snapshot(
+        self,
+        *,
+        state: GameState,
+        period: int,
+        seconds_to_start: int,
+        display_clock: str,
+        status: str,
+    ) -> EnhancedGameSnapshot:
+        timing = GameTiming(
+            current_period=period,
+            period_name=status,
+            period_max=3,
+            display_clock=display_clock,
+            clock_running=state == GameState.LIVE,
+            is_intermission=False,
+            is_overtime=False,
+            is_shootout=False,
+        )
+        return EnhancedGameSnapshot(
+            sport=self.sport,
+            event_id=f"{self.sport.value}-demo",
+            start_time_local=self._start_time,
+            state=state,
+            home=self._home,
+            away=self._away,
+            timing=timing,
+            seconds_to_start=seconds_to_start,
+            status_detail=status,
+        )
+
+
+SPORT_SIMULATOR_FACTORIES: Dict[SportType, type[BaseSportDemo]] = {
+    SportType.WNBA: WNBADemoSimulator,
+    SportType.NHL: NHLDemoSimulator,
+}
 
 
 class DemoSimulator:
-    """Simple time-based simulator for a single WNBA game.
+    """Facade that coordinates sport-specific demo simulators."""
 
-    Behavior:
-    - Starts in PRE for ~45s, then goes LIVE for 4 periods of 10 minutes each.
-    - Advances clock based on wall time; bumps score occasionally (10–30s).
-    - Ends in FINAL and keeps showing for the day.
-    """
+    def __init__(
+        self,
+        multi_cfg: MultiSportAppConfig,
+        legacy_cfg: AppConfig,
+        *,
+        options: Optional[DemoOptions] = None,
+    ) -> None:
+        self.multi_cfg = multi_cfg
+        self.legacy_cfg = legacy_cfg
+        self.options = options or DemoOptions()
+        self.rng = random.Random()
+        now = datetime.now(legacy_cfg.tz)
+        self.simulators: List[BaseSportDemo] = self._build_simulators(now)
+        if not self.simulators:
+            # fall back to highest priority legacy favorites as generic demo
+            fallback = GenericFallbackDemo(
+                sport=SportType.WNBA,
+                tz=legacy_cfg.tz,
+                favorites=legacy_cfg.favorites,
+                rng=self.rng,
+            )
+            self.simulators = [fallback]
+        self._current_index = 0
+        self._last_switch = now
 
-    QUARTER_LEN = 10 * 60  # 10 minutes
+    def _build_simulators(self, now_local: datetime) -> List[BaseSportDemo]:
+        order = self._determine_order()
+        simulators: List[BaseSportDemo] = []
+        for sport in order:
+            favorites = self.multi_cfg.get_favorites_for_sport(sport)
+            factory = SPORT_SIMULATOR_FACTORIES.get(sport, GenericFallbackDemo)
+            simulator = factory(sport=sport, tz=self.multi_cfg.tz or self.legacy_cfg.tz, favorites=favorites, rng=self.rng)
+            simulator.reset(now_local)
+            simulators.append(simulator)
+        return simulators
 
-    def __init__(self, cfg: AppConfig):
-        self.cfg = cfg
-        now = datetime.now(cfg.tz)
-        self.start_time = now + timedelta(seconds=10)
-        self.random = random.Random()
-        self.random.seed(int(now.timestamp()))
-
-        # Choose teams from favorites if possible
-        away_abbr = None
-        home_abbr = None
-        away_name = None
-        home_name = None
-        away_id = None
-        home_id = None
-        if cfg.favorites:
-            away = cfg.favorites[0]
-            away_abbr = away.abbr or (away.name[:3].upper() if away.name else "AWY")
-            away_name = away.name or "Away"
-            away_id = away.id or "AWY"
-            if len(cfg.favorites) > 1:
-                home = cfg.favorites[1]
-                home_abbr = home.abbr or (home.name[:3].upper() if home.name else "HOM")
-                home_name = home.name or "Home"
-                home_id = home.id or "HOM"
-        away_abbr = away_abbr or "AWY"
-        home_abbr = home_abbr or "HOM"
-        away_name = away_name or "Away"
-        home_name = home_name or "Home"
-        away_id = away_id or "AWY"
-        home_id = home_id or "HOM"
-
-        self.base = GameSnapshot(
-            event_id="demo",
-            start_time_local=self.start_time,
-            state=GameState.PRE,
-            period=0,
-            display_clock="",
-            home=TeamSide(id=home_id, name=home_name, abbr=home_abbr, score=0),
-            away=TeamSide(id=away_id, name=away_name, abbr=away_abbr, score=0),
-            seconds_to_start=10,
-            status_detail="Demo",
-        )
-
-        self.next_score_ts = self.start_time  # will schedule after tip
-
-    def _format_clock(self, secs: int) -> str:
-        secs = max(0, secs)
-        m, s = divmod(secs, 60)
-        return f"{m:02d}:{s:02d}"
+    def _determine_order(self) -> List[SportType]:
+        if self.options.forced_sports:
+            return [sport for sport in self.options.forced_sports]
+        enabled = self.multi_cfg.get_enabled_sports()
+        return enabled or [SportType.WNBA]
 
     def get_snapshot(self, now_local: datetime) -> Optional[GameSnapshot]:
-        # PRE
-        if now_local < self.start_time:
-            secs_to_start = int((self.start_time - now_local).total_seconds())
-            return replace(self.base, state=GameState.PRE, period=0, display_clock="", seconds_to_start=secs_to_start)
+        if not self.simulators:
+            return None
+        if self._should_rotate(now_local):
+            self._advance_rotation(now_local)
+        current = self.simulators[self._current_index]
+        return current.get_snapshot(now_local)
 
-        # LIVE or FINAL
-        elapsed = int((now_local - self.start_time).total_seconds())
-        period = min(4, 1 + elapsed // self.QUARTER_LEN)
-        period_elapsed = elapsed % self.QUARTER_LEN
-        remaining = self.QUARTER_LEN - period_elapsed
+    def _should_rotate(self, now_local: datetime) -> bool:
+        if len(self.simulators) <= 1:
+            return False
+        if self.options.rotation_seconds <= 0:
+            return False
+        return (now_local - self._last_switch).total_seconds() >= self.options.rotation_seconds
 
-        # Score bump scheduling (only during LIVE)
-        if period <= 4:
-            if now_local >= self.next_score_ts:
-                # Randomly assign 1, 2, or 3 points to a team
-                pts = self.random.choice([1, 2, 3, 2])
-                if self.random.random() < 0.5:
-                    self.base.away.score += pts
-                else:
-                    self.base.home.score += pts
-                # Next score in 10–30 seconds
-                self.next_score_ts = now_local + timedelta(seconds=self.random.randint(10, 30))
+    def _advance_rotation(self, now_local: datetime) -> None:
+        self._current_index = (self._current_index + 1) % len(self.simulators)
+        self.simulators[self._current_index].reset(now_local)
+        self._last_switch = now_local
 
-        if period <= 4:
-            return replace(
-                self.base,
-                state=GameState.LIVE,
-                period=period,
-                display_clock=self._format_clock(remaining),
-                seconds_to_start=-1,
-                status_detail=f"Q{period}",
-            )
-        else:
-            # FINAL
-            return replace(
-                self.base,
-                state=GameState.FINAL,
-                period=4,
-                display_clock="00:00",
-                seconds_to_start=-1,
-                status_detail="Final",
-            )
+
+def parse_demo_options(
+    *,
+    rotation_seconds: Optional[int],
+    forced_sports: Optional[Iterable[str]],
+) -> DemoOptions:
+    forced: Optional[List[SportType]] = None
+    if forced_sports:
+        forced = []
+        for value in forced_sports:
+            try:
+                forced.append(SportType(value.strip()))
+            except ValueError:
+                continue
+    seconds = rotation_seconds if rotation_seconds is not None else DEFAULT_ROTATION_SECONDS
+    return DemoOptions(rotation_seconds=max(0, seconds), forced_sports=forced)

--- a/src/demo/simulator.py
+++ b/src/demo/simulator.py
@@ -14,7 +14,7 @@ from src.model.sport_game import EnhancedGameSnapshot, GameTiming, SportTeam
 from src.sports.base import SportType
 
 DEFAULT_ROTATION_SECONDS = 120
-DEFAULT_PREGAME_SECONDS = 45
+DEFAULT_PREGAME_SECONDS = 10
 
 
 @dataclass

--- a/tests/test_demo_mode.py
+++ b/tests/test_demo_mode.py
@@ -1,0 +1,117 @@
+import unittest
+from datetime import timedelta
+
+from src.demo.simulator import DemoSimulator, NHLDemoSimulator, WNBADemoSimulator, parse_demo_options
+from src.config.multi_sport_types import (
+    SportFavorites,
+    create_default_multi_sport_config,
+    convert_multi_sport_to_legacy,
+)
+from src.config.types import FavoriteTeam
+from src.sports.base import SportType
+from src.model.game import GameState
+
+
+class DemoSimulatorTests(unittest.TestCase):
+    def _enable_sport(self, cfg, sport: SportType, favorites: list[FavoriteTeam]) -> None:
+        for sport_cfg in cfg.sports:
+            if sport_cfg.sport == sport:
+                sport_cfg.enabled = True
+                if favorites:
+                    sport_cfg.teams = favorites
+                break
+        else:
+            cfg.sports.append(
+                SportFavorites(sport=sport, enabled=True, priority=len(cfg.sports) + 1, teams=favorites)
+            )
+        cfg.enabled_sports = cfg.get_enabled_sports()
+
+    def test_wnba_demo_transitions(self) -> None:
+        cfg = create_default_multi_sport_config()
+        legacy = convert_multi_sport_to_legacy(cfg)
+        demo = DemoSimulator(cfg, legacy)
+        simulator = demo.simulators[0]
+        self.assertIsInstance(simulator, WNBADemoSimulator)
+
+        start = simulator._start_time  # type: ignore[attr-defined]
+        pre_snapshot = demo.get_snapshot(start - timedelta(seconds=5))
+        self.assertIsNotNone(pre_snapshot)
+        self.assertEqual(pre_snapshot.state, GameState.PRE)
+
+        live_snapshot = demo.get_snapshot(start + timedelta(seconds=5))
+        self.assertIsNotNone(live_snapshot)
+        self.assertEqual(live_snapshot.state, GameState.LIVE)
+
+        final_snapshot = demo.get_snapshot(
+            start
+            + timedelta(seconds=WNBADemoSimulator.period_seconds * WNBADemoSimulator.period_count + 60)
+        )
+        self.assertIsNotNone(final_snapshot)
+        self.assertEqual(final_snapshot.state, GameState.FINAL)
+
+    def test_rotation_between_sports(self) -> None:
+        cfg = create_default_multi_sport_config()
+        self._enable_sport(
+            cfg,
+            SportType.NHL,
+            [
+                FavoriteTeam(name="Seattle Kraken", id="55", abbr="SEA"),
+                FavoriteTeam(name="Vancouver Canucks", id="23", abbr="VAN"),
+            ],
+        )
+        legacy = convert_multi_sport_to_legacy(cfg)
+        options = parse_demo_options(rotation_seconds=1, forced_sports=["wnba", "nhl"])
+        demo = DemoSimulator(cfg, legacy, options=options)
+        self.assertEqual(len(demo.simulators), 2)
+
+        start = demo.simulators[0]._start_time  # type: ignore[attr-defined]
+        first_snapshot = demo.get_snapshot(start)
+        self.assertIsNotNone(first_snapshot)
+        first_index = demo._current_index
+
+        later = start + timedelta(seconds=2)
+        second_snapshot = demo.get_snapshot(later)
+        self.assertIsNotNone(second_snapshot)
+        second_index = demo._current_index
+        self.assertNotEqual(first_index, second_index)
+
+    def test_nhl_demo_reaches_final(self) -> None:
+        cfg = create_default_multi_sport_config()
+        # Disable WNBA to focus on NHL only
+        for sport_cfg in cfg.sports:
+            sport_cfg.enabled = False
+        self._enable_sport(
+            cfg,
+            SportType.NHL,
+            [
+                FavoriteTeam(name="Seattle Kraken", id="55", abbr="SEA"),
+                FavoriteTeam(name="Edmonton Oilers", id="22", abbr="EDM"),
+            ],
+        )
+        legacy = convert_multi_sport_to_legacy(cfg)
+        options = parse_demo_options(rotation_seconds=0, forced_sports=["nhl"])
+        demo = DemoSimulator(cfg, legacy, options=options)
+        simulator = demo.simulators[0]
+        self.assertIsInstance(simulator, NHLDemoSimulator)
+
+        # Keep scores level to drive overtime/shootout path deterministically
+        simulator._home.score = 2  # type: ignore[attr-defined]
+        simulator._away.score = 2  # type: ignore[attr-defined]
+        simulator._next_score_time = simulator._start_time + timedelta(days=1)  # type: ignore[attr-defined]
+
+        regulation_end = (
+            simulator._start_time  # type: ignore[attr-defined]
+            + timedelta(seconds=NHLDemoSimulator.regulation_periods * NHLDemoSimulator.regulation_period_seconds)
+        )
+        overtime_snapshot = demo.get_snapshot(regulation_end + timedelta(seconds=60))
+        self.assertIsNotNone(overtime_snapshot)
+        self.assertEqual(overtime_snapshot.state, GameState.LIVE)
+
+        final_snapshot = demo.get_snapshot(regulation_end + timedelta(seconds=NHLDemoSimulator.overtime_seconds + 300))
+        self.assertIsNotNone(final_snapshot)
+        self.assertEqual(final_snapshot.state, GameState.FINAL)
+        self.assertIn(final_snapshot.status_detail.lower(), {"final", "final/ot", "final/so"})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace single-sport demo simulator with sport-aware framework (WNBA + NHL + fallback)
- add CLI/env controls for demo sport rotation and update docs/tests/CI
- shorten demo pregame countdown to 10s for faster cycles

## Testing
- python -m unittest tests.test_demo_mode tests.test_multi_sport_config
- npm run lint