### PR TITLE
🐛(dependencies): Fix supabase compatibility issues on Raspberry Pi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ Pillow==10.4.0
 python-dotenv==1.0.1
 python-dateutil==2.8.2
 websocket-client==1.8.0
+websockets==13.1
 cairosvg==2.7.1
-supabase==2.4.0
+supabase==2.10.0


### PR DESCRIPTION
## Summary
Update dependency versions to fix compatibility issues when running on Raspberry Pi.

## Changes
- Upgrade supabase from 2.4.0 to 2.10.0 to fix proxy parameter error
- Add websockets 13.1 for asyncio module support required by newer supabase
- Fixes ModuleNotFoundError: No module named 'websockets.asyncio'

## Test plan
- [x] Install updated dependencies with `pip install -r requirements.txt`
- [x] Verify app starts without ModuleNotFoundError
- [x] Test Supabase connection works correctly
- [x] Verify scoreboard displays data as expected on Raspberry Pi

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have tested on Raspberry Pi hardware
- [x] My changes generate no new warnings