### PR TITLE
✨ Prioritize LIVE games with favorite teams over league order

### DIFF
--- a/app.py
+++ b/app.py
@@ -162,9 +162,10 @@ def main():
                     # Build favorite teams dictionary for aggregator
                     favorite_teams = {}
                     if device_config:
-                        # Convert TeamInfo objects to team IDs for aggregator
+                        # Convert TeamInfo objects to abbreviations for aggregator
+                        # Use abbreviations as they're more reliable for matching
                         for league_code, teams in device_config.favorite_teams.items():
-                            favorite_teams[league_code] = [team.team_id for team in teams]
+                            favorite_teams[league_code] = [team.abbreviation for team in teams]
 
                     snapshot = aggregator.get_featured_game(
                         now_local.date(),


### PR DESCRIPTION
## Summary
LIVE games with your favorite teams now always display, regardless of league priority settings.

## Problem
When WNBA had higher priority than NHL, the system would show any WNBA game (even without favorites) over an NHL game with your favorite team playing live.

Example:
- WNBA priority: 1, NHL priority: 2
- LV @ IND (WNBA, no favorites) was shown
- WSH @ NJD (NHL, NJD is favorite) was not shown

## Solution
Added a massive priority boost (+1000 points) for LIVE games with favorite teams, ensuring they always display regardless of league order.

### Priority Scoring (new):
- **NHL LIVE with favorite**: 99 (base) + 30 (favorite) + 1000 (live+favorite) = 1129 points
- **WNBA LIVE (no favorite)**: 100 (base) + 50 (live) = 150 points
- **NHL LIVE (no favorite)**: 99 (base) + 50 (live) = 149 points

## Changes
1. Modified `_calculate_game_priority()` to give +1000 boost for LIVE games with favorites
2. Fixed favorite team matching to use abbreviations instead of team IDs
3. Added logic to check both team names and abbreviations for favorite matches

## Testing
Verified that with NJD playing live, the system now selects the NHL game over WNBA games.